### PR TITLE
Fix pom.xml error for java-samples 

### DIFF
--- a/java-samples/pom.xml
+++ b/java-samples/pom.xml
@@ -19,6 +19,7 @@
         <testSourceDirectory>src/test</testSourceDirectory>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <configuration>


### PR DESCRIPTION
Hello,

I just found a small issue with pom.xml for java sample. Could you check?

1. Issue
- Clone https://github.com/JetBrains/intellij-samples
- Open pom.xml for java-samples
- IntelliJ IDEA complains maven-surefire-plugin cannot be found

2. Fix
- Add org.apache.maven.plugins line in the maven-surefire-plugin plugin entry