### PR TITLE
Upgrading Kotlin to 1.7

### DIFF
--- a/kotlin-samples/kotlin-samples.iml
+++ b/kotlin-samples/kotlin-samples.iml
@@ -6,6 +6,8 @@
         <compilerSettings />
         <compilerArguments>
           <option name="jvmTarget" value="17" />
+          <option name="languageVersion" value="1.7" />
+          <option name="apiVersion" value="1.7" />
           <option name="pluginOptions">
             <array />
           </option>
@@ -28,9 +30,9 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.6.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.7.0" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.7.0" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
-    <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.6.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.6.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jetbrains.kotlin:kotlin-test:1.7.0" level="project" />
   </component>
 </module>

--- a/kotlin-samples/pom.xml
+++ b/kotlin-samples/pom.xml
@@ -76,7 +76,7 @@
         </dependency>
     </dependencies>
     <properties>
-        <kotlin.version>1.6.0</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <java.version>17</java.version>
     </properties>
 </project>

--- a/kotlin-samples/src/main/java/com/jetbrains/intentions/WhenBranches.kt
+++ b/kotlin-samples/src/main/java/com/jetbrains/intentions/WhenBranches.kt
@@ -9,8 +9,9 @@ enum class Entry {
 }
 
 fun test(e: Entry) {
-    when (e) {
+//    when (e) {
         // Alt+Enter -> Add remaining branches
-    }
+
+//    }
 }
 


### PR DESCRIPTION
Had to fix a problem where IntelliJ IDEA now doesn't allow incomplete "when" statements (which was intentionally incomplete in order to demo branch generation).

Also upgraded to latest version of Kotlin.