### PR TITLE
Erm. One small IntelliJ config file that was hiding when I created the last pull request.

### DIFF
--- a/kotlin-samples/kotlin-samples.iml
+++ b/kotlin-samples/kotlin-samples.iml
@@ -28,7 +28,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="17" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.7.10" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib-common:1.7.10" level="project" />


### PR DESCRIPTION
I specifically want IntelliJ IDEA to use Java 17 to compile Kotlin rather than the project SDK, just in case there are any incompatibilities when new versions of Java come out.